### PR TITLE
[Deep Research + Cursor Background Agent] Refactor state management for FastAPI

### DIFF
--- a/server/app/main.py
+++ b/server/app/main.py
@@ -85,7 +85,7 @@ def start_streams(loop, camera_config: list):
 async def lifespan(app: FastAPI):
     loop = asyncio.get_running_loop()
     init_db()
-    await setup_handlers() # Initialize signal handlers before starting streams
+    await setup_handlers(app) # Pass app instance to setup_handlers
     
     camera_config = []
     try:
@@ -95,10 +95,10 @@ async def lifespan(app: FastAPI):
         logger.error("Error: CAM_PROXY_CONFIG environment variable is not valid JSON")
 
     run_id = get_next_run_id()
-    set_run_id(run_id)
+    set_run_id(app, run_id)  # Pass app instance to set_run_id
     initial_predictions = run_initial_inference(run_id, camera_config)
     if initial_predictions:
-        set_initial_predictions(initial_predictions)
+        set_initial_predictions(app, initial_predictions)  # Pass app instance to set_initial_predictions
         logger.info(f"Initial inference complete for cameras: {list(initial_predictions.keys())}")
 
     start_streams(loop, camera_config)

--- a/server/app/state.py
+++ b/server/app/state.py
@@ -1,7 +1,8 @@
 """
-Global state for the application.
+State management for the application using FastAPI's application state.
 """
 from typing import Dict, Any, List
+from fastapi import FastAPI
 from sqlmodel import Session, select, func
 from app.db import get_session
 from app.models.detection import Detection
@@ -9,22 +10,18 @@ from app.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
-# This dictionary will hold the application's global state.
-# For example, it can store initialization results or other shared data.
-app_state: Dict[str, Any] = {
-    "initial_predictions": {},
-}
+def set_initial_predictions(app: FastAPI, predictions: Dict[str, List[dict]]):
+    """Sets the initial predictions in the application state, keyed by camera_id."""
+    app.state.initial_predictions = predictions
 
-def set_initial_predictions(predictions: Dict[str, List[dict]]):
-    """Sets the initial predictions in the global state, keyed by camera_id."""
-    app_state["initial_predictions"] = predictions
+def get_initial_predictions(app: FastAPI) -> Dict[str, List[dict]]:
+    """Gets the initial predictions from the application state."""
+    return getattr(app.state, 'initial_predictions', {})
 
-def get_initial_predictions() -> Dict[str, List[dict]]:
-    """Gets the initial predictions from the global state."""
-    return app_state.get("initial_predictions", {})
+def get_run_id(app: FastAPI) -> int:
+    """Gets the current run ID from the application state."""
+    return getattr(app.state, 'run_id', 0)
 
-def get_run_id() -> int:
-    return app_state.get("run_id", 0)
-
-def set_run_id(run_id: int):
-    app_state["run_id"] = run_id
+def set_run_id(app: FastAPI, run_id: int):
+    """Sets the current run ID in the application state."""
+    app.state.run_id = run_id


### PR DESCRIPTION
Refactor global state management to use FastAPI's `app.state` for explicit and lifecycle-aware state handling.

Prompt: _Refactor global state management to use FastAPI’s application state. In app/state.py (and wherever app_state is used), remove the global dictionary and instead attach state to the FastAPI app within the lifespan function. For example, store run_id and initial_predictions in app.state during startup, and modify get_run_id, set_run_id, etc., to use app.state (or FastAPI’s lifespan return state) for these values. Ensure all parts of the code (e.g. where get_run_id() is called) now retrieve the data from the app’s state. This makes the state usage explicit and tied to the app lifecycle._

## Changes Made

### 1. **`server/app/state.py`** - Core State Management
- **Removed** the global `app_state` dictionary
- **Updated** all functions to accept a `FastAPI` app instance parameter:
  - `set_initial_predictions(app: FastAPI, predictions: Dict[str, List[dict]])`
  - `get_initial_predictions(app: FastAPI) -> Dict[str, List[dict]]`
  - `set_run_id(app: FastAPI, run_id: int)`
  - `get_run_id(app: FastAPI) -> int`
- **Now uses** `app.state.initial_predictions` and `app.state.run_id` instead of global dictionary

### 2. **`server/app/main.py`** - Application Startup
- **Updated** the lifespan function to pass the app instance to state functions:
  - `set_run_id(app, run_id)`
  - `set_initial_predictions(app, initial_predictions)`
  - `setup_handlers(app)`

### 3. **`server/app/utils/handlers.py`** - Signal Handlers
- **Updated** `setup_handlers()` to accept the app parameter
- **Added** a module-level app instance storage mechanism to make the app accessible in signal handlers
- **Updated** `handle_detections_storage()` to use `get_run_id(_app_instance)` instead of the global state

### 4. **`server/app/routes/websockets.py`** - WebSocket Routes
- **Updated** `get_initial_data()` to accept a WebSocket parameter
- **Modified** the function to use `get_initial_predictions(websocket.app)` to access the app state through the WebSocket connection

## Benefits of This Refactoring

1. **Explicit State Management**: State is now explicitly tied to the FastAPI application instance
2. **Lifecycle Awareness**: State is automatically managed through the app's lifespan
3. **No Global Variables**: Eliminates the global dictionary that could cause issues in testing or multi-instance scenarios
4. **Better Testability**: Each app instance has its own state, making unit testing easier
5. **Type Safety**: All state access is now typed with the FastAPI app instance

## How It Works Now

- During app startup in the `lifespan` function, the `run_id` and `initial_predictions` are stored in `app.state`
- All functions that need to access state now require the app instance to be passed to them
- WebSocket connections can access the app state through `websocket.app`
- Signal handlers store a reference to the app instance to access state when needed

The refactoring maintains all existing functionality while making the state management more robust and following FastAPI best practices.